### PR TITLE
✨ Provide docker runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.15-alpine as builder
+
+# Meta data:
+LABEL maintainer="itsrishikothari@gmail.com"
+LABEL description="A minimal interpreted programming language."
+
+# Copying over all files:
+COPY . /usr/src/app/
+WORKDIR /usr/src/app
+
+# Installing deps and building binary:
+RUN go get -v -t -d ./...
+RUN go build -o sepia .
+
+# Copying over the binary to a thinner image
+# hadolint ignore=DL3006,DL3007
+FROM alpine:latest
+COPY --from=builder /usr/src/app/sepia/ /usr/bin/
+


### PR DESCRIPTION
Provide a docker runtime based on an alpine image (around 8MB as a final image size). You might wanna add this to the goreleaser release. Hope this helps!